### PR TITLE
ARH policy bulk update

### DIFF
--- a/policy-bulk-update/README.md
+++ b/policy-bulk-update/README.md
@@ -1,0 +1,15 @@
+# arh-bulk-policy-update
+
+
+
+## Use Case Details
+
+Adding a capability of bulk policy update to multiple Resilience Hub applications. For example, the customer would like to assign same policy XYZ to 20 applications already onboarded in Resilience Hub.
+The script takes the below as input:
+1. ARN of Resilience Hub policy
+2. List of target app ARNs with following alternatives:
+    a. Array of script parameters
+    b. Filename with app ARNs per line
+3. Optional parameter: --assessmentSchedule with valid values Disabled | Daily
+
+Script will call Resilience Hub API [UpdateApp] (https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_UpdateApp.html) to update policy of every given Resilience Hub application and optionally turn on/off daily assessments.

--- a/policy-bulk-update/README.md
+++ b/policy-bulk-update/README.md
@@ -12,4 +12,4 @@ The script takes the below as input:
     b. Filename with app ARNs per line
 3. Optional parameter: --assessmentSchedule with valid values Disabled | Daily
 
-Script will call Resilience Hub API [UpdateApp] (https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_UpdateApp.html) to update policy of every given Resilience Hub application and optionally turn on/off daily assessments.
+Script will call Resilience Hub API [UpdateApp](https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_UpdateApp.html) to update policy of every given Resilience Hub application and optionally turn on/off daily assessments.

--- a/policy-bulk-update/bulk-arh-policy-update.py
+++ b/policy-bulk-update/bulk-arh-policy-update.py
@@ -1,0 +1,74 @@
+'''  Bulk policy update to multiple Resilience Hub applications
+    Inputs: 
+        -p, --policy-arn: ARN of the Resilience Hub Policy
+        -a, --target-app-arns: Target ARH App ARNs
+        -f, --target-app-file: File containing the ARH App ARNs
+        -s, --schedule: Schedule for the policy
+        -v, --verbose: Verbose output
+'''
+
+from pprint import pprint
+import argparse
+
+import boto3
+
+
+def update_policy_for_an_app(arh, policy_arn, app_arn, schedule, verbose):
+    if verbose:
+        print(f"Updating policy {policy_arn} for {app_arn}")
+    try:
+        if schedule is not None:
+            response = arh.update_app(
+                policyArn=policy_arn,
+                appArn=app_arn,
+                assessmentSchedule=schedule
+            )
+        else:
+            response = arh.update_app(
+                policyArn=policy_arn,
+                appArn=app_arn
+            )
+    except:
+        print(f"Error updating policy {policy_arn} for {app_arn}")
+        raise
+
+    if verbose:
+        pprint(response)
+
+def update_policy_for_apps (arh, policy_arn, app_arns, schedule, verbose):
+    for app_arn in app_arns.split(','):
+        update_policy_for_an_app(arh, policy_arn, app_arn, schedule, verbose)
+
+def update_policy_for_apps_from_file(arh, policy_arn, file_name, schedule, verbose):
+    with open(file_name) as f:
+        for app_arn in f:
+            update_policy_for_an_app(arh, policy_arn, app_arn.strip(), schedule, verbose)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Bulk policy update script for AWS Resilience Hub")
+    parser.add_argument("-p", "--policy-arn", type=str,
+        help="ARN of the Resilience Hub Policy", required=True)
+
+    # You need either the list of app ARNs or the file containing the list of app ARNs
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-a", "--target-app-arns", type=str, help="Target ARH App ARNs")
+    group.add_argument("-f", "--target-app-file", type=str, help="File containing the ARH App ARNs")
+
+    parser.add_argument("-s", "--schedule", type=str,
+        help="Assesmant Schedule - valid values Disabled|Daily",choices=['Disabled', 'Daily'],)
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose mode")
+    args = parser.parse_args()
+
+    # Parse the ARN of the policy to get the AWS region
+    region = args.policy_arn.split(':')[3]
+    if args.verbose:
+        print(f"AWS Region {region}")
+    client = boto3.client('resiliencehub',region)
+
+    if args.target_app_arns is not None:
+        update_policy_for_apps(client, args.policy_arn, args.target_app_arns,
+            args.schedule, args.verbose)
+    elif args.target_app_file is not None:
+        update_policy_for_apps_from_file(client, args.policy_arn, args.target_app_file,
+            args.schedule, args.verbose)
+    print("Policy update completed")

--- a/policy-bulk-update/bulk-arh-policy-update.py
+++ b/policy-bulk-update/bulk-arh-policy-update.py
@@ -1,7 +1,7 @@
 '''  Bulk policy update to multiple Resilience Hub applications
     Inputs: 
         -p, --policy-arn: ARN of the Resilience Hub Policy
-        -a, --target-app-arns: Target ARH App ARNs seperated by comma (,)
+        -a, --target-app-arns: Target ARH App ARNs seperated by comma (,) OR
         -f, --target-app-file: File containing the ARH App ARNs - one per line
         -s, --schedule: Schedule for the policy
         -v, --verbose: Verbose output

--- a/policy-bulk-update/bulk-arh-policy-update.py
+++ b/policy-bulk-update/bulk-arh-policy-update.py
@@ -1,8 +1,8 @@
 '''  Bulk policy update to multiple Resilience Hub applications
     Inputs: 
         -p, --policy-arn: ARN of the Resilience Hub Policy
-        -a, --target-app-arns: Target ARH App ARNs
-        -f, --target-app-file: File containing the ARH App ARNs
+        -a, --target-app-arns: Target ARH App ARNs seperated by comma (,)
+        -f, --target-app-file: File containing the ARH App ARNs - one per line
         -s, --schedule: Schedule for the policy
         -v, --verbose: Verbose output
 '''
@@ -51,8 +51,8 @@ if __name__ == "__main__":
 
     # You need either the list of app ARNs or the file containing the list of app ARNs
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("-a", "--target-app-arns", type=str, help="Target ARH App ARNs")
-    group.add_argument("-f", "--target-app-file", type=str, help="File containing the ARH App ARNs")
+    group.add_argument("-a", "--target-app-arns", type=str, help="Target ARH App ARNs seperated by comma")
+    group.add_argument("-f", "--target-app-file", type=str, help="File containing the ARH App ARNs - one per line")
 
     parser.add_argument("-s", "--schedule", type=str,
         help="Assesmant Schedule - valid values Disabled|Daily",choices=['Disabled', 'Daily'],)

--- a/policy-bulk-update/pylint.config
+++ b/policy-bulk-update/pylint.config
@@ -1,0 +1,9 @@
+[MASTER]
+init-hook='import sys; sys.path.append(".")'
+[MESSAGES CONTROL]
+# C0114: Missing module docstring (missing-module-docstring)
+# C0116: Missing function or method docstring (missing-function-docstring)
+# C0301: Line too long (line-too-long)
+# E0401: Unable to import 'module' (import-error)
+# R0801: Similar lines in 2 files
+disable=C0114,C0116,C0301,E0401,R0801


### PR DESCRIPTION
Customers are asking for a capability of bulk policy update to multiple Resilience Hub applications. 
For example, they would like to assign same policy XYZ to 20 applications already onboarded in Resilience Hub.

We would like to provide our customers a script (bash or python) to get as input:
ARN of Resilience Hub policy
List of target app ARNs with following alternatives:
Array of script parameters
Filename with app ARNs per line
Optional parameter: --assessmentSchedule with valid values Disabled | Daily
Script will call Resilience Hub API UpdateApp to update policy of every given Resilience Hub application and optionally turn on/off daily assessments

