### PR TITLE
Provide ARH application name using app_name tags

### DIFF
--- a/inputsource-eventbridge-integration/README.md
+++ b/inputsource-eventbridge-integration/README.md
@@ -24,7 +24,7 @@ Steps:
 2. During the CloudFormation deployment, add the following tags: 
     1. **(Required)**`app_criticality`, value: STRING from a pre-formatted list from ARH tiers: Valid Values: `MissionCritical | Critical | Important | CoreServices | NonCritical`
     2. **(Optional)** `app_owner`, value: ARN of valid SNS Topic that will receive the resilience assessment notifications
-    3. **(Optional)** `app_name`, value: Name of the new or existing Resilience Hub application 
+    3. **(Required)** `app_name`, value: Name of the new or existing Resilience Hub application 
    
 ![Add Tags Image](add-tag.png)
 
@@ -38,7 +38,7 @@ Steps:
 3. During the object upload, add the following tags: 
     1. **(Required)**`app_criticality`, value: STRING from a pre-formatted list from ARH tiers: Valid Values: `MissionCritical | Critical | Important | CoreServices | NonCritical`
     2. **(Optional)** `app_owner`, value: ARN of valid SNS Topic that will receive the resilience assessment notification
-    3. **(Optional)** `app_name`, value: Name of the new or existing Resilience Hub application
+    3. **(Required)** `app_name`, value: Name of the new or existing Resilience Hub application
 
 This will result an automatic creation or update to existing applications in ARH which notifies the application owner of any detected drift or assessment failures.
    
@@ -63,8 +63,8 @@ For Terraform state file stored in S3 bucket, the Step Function branches off off
 
 ## Important Notes
 #### CloudFormation Stacks
-- Deleting a template that was deployed with the tag will also result in the application created in ARH being deleted as well.
-- To import existing stacks into ARH, update the stack and add the `app_criticality` tag.
+- Deleting a template that was deployed with the mandatory tags will also result in the application created in ARH being deleted as well.
+- To import existing stacks into ARH, update the stack and add the `app_name` and `app_criticality` tags.
 #### Terraform state file in S3 bucket
-- Deleting an object with the `app_criticality` tag will also result in the application created in ARH being deleted as well.
-- To import existing Terraform state files into ARH, re-upload the object and add the `app_criticality` tag.
+- Deleting an object with the mandatory tags will also result in the application created in ARH being deleted as well.
+- To import existing Terraform state files into ARH, re-upload the object and add the `app_name` and `app_criticality` tags.

--- a/inputsource-eventbridge-integration/arh_input_source_eb_template.yaml
+++ b/inputsource-eventbridge-integration/arh_input_source_eb_template.yaml
@@ -283,11 +283,15 @@ Resources:
             Default: Wait for Import
             OutputPath: $.Apps.App
             Type: Choice
-          Check Policy Tag:
+          Check Mandatory Tags:
             Choices:
-              - IsPresent: true
+              - Comment: Check if both Policy and name tags are present
                 Next: ListApps
-                Variable: $.ForEachTag.PolicyArn[0]
+                And:
+                  - IsPresent: true
+                    Variable: $.ForEachTag.PolicyArn[0]
+                  - IsNull: false
+                    Variable: $.ArhPayload.ArhApplicationName
             Default: Create/Update Successful
             Type: Choice
           Create, Update, Delete:
@@ -450,10 +454,9 @@ Resources:
                   End: true
                   Type: Pass
             ItemsPath: $.ArhPayload.Tags
-            Next: Check Policy Tag
+            Next: Check Mandatory Tags
             ResultPath: $.ForEachTag
             ResultSelector:
-              ArhAppName.$: $..[?(@.ArhAppName)]
               Notify.$: $..[?(@.EventType)]
               PolicyArn.$: $..[?(@.PolicyArn)]
             Type: Map
@@ -698,7 +701,7 @@ Resources:
           cfn_client = boto3.client("cloudformation")
           def lambda_handler(event, context):
             event_source = event["source"]
-            arhAppName = ""
+            arhAppName = None
             resourcePath = ""
             arhAppOperation=""
             arh_app_tags = []
@@ -706,8 +709,6 @@ Resources:
               try:
                   bucket_name = event["detail"]["bucket"]["name"]
                   object_key = event["detail"]["object"]["key"]
-                  #resilience hub application name - unique
-                  arhAppName = bucket_name + '-'+ object_key.replace("/","-").replace(".","-")
                   resourcePath = 's3://'+bucket_name+'/'+object_key
                   if event["detail"]["reason"] == 'DeleteObject':
                     arhAppOperation = 'DELETE_COMPLETE'
@@ -729,9 +730,8 @@ Resources:
                 cfn_client_response = cfn_client.describe_stacks(
                     StackName = cfn_stack_id
                 )
-                #resilience hub application name - unique
+                
                 if ("Stacks" in cfn_client_response and len(cfn_client_response["Stacks"]) > 0):
-                  arhAppName = cfn_client_response["Stacks"][0]["StackName"]
                   arhAppOperation = cfn_client_response["Stacks"][0]["StackStatus"]
                   arh_app_tags = cfn_client_response["Stacks"][0]["Tags"]
                   resourcePath = cfn_client_response["Stacks"][0]["StackId"]


### PR DESCRIPTION
*Issue #, if available:*
ARH application fails when the auto-created application name length is greater than ARH limits.
*Description of changes:*
* Current logic uses either the CloudFormation stack name or S3 prefix+object name to determine the newly created ARH app name. The app creation fails when the name exceeds the ARH limits for application name length.
* Modified the logic to use the value passed in **app_name** tag for the ARH name. The tag is mandatory, if not passed the StepFunction workflow will exit.
* Updated instructions to reflect the changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
